### PR TITLE
Fixed "Duplicate Column Name" Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # spdMerlin
 
-## v4.4.7
-### Updated on 2025-May-26
+## v4.4.8
+### Updated on 2025-Jun-02
 ## About
 spdMerlin is an internet speedtest and monitoring tool for AsusWRT Merlin with charts for daily, weekly and monthly summaries. It tracks download/upload bandwidth as well as latency, jitter and packet loss.
 


### PR DESCRIPTION
Fixed "duplicate column name" errors reported by SQLite3 during initial installation when the database "upgrade" was being performed.

The issue was reported in the SNB Forums:
https://www.snbforums.com/threads/sqlite3-errors-when-installing-latest-version.94858/#post-957558