### PR TITLE
Fixed "Duplicate Column Name" Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # spdMerlin
 
-## v4.4.7
-### Updated on 2025-May-26
+## v4.4.8
+### Updated on 2025-Jun-02
 ## About
 spdMerlin is an internet speedtest and monitoring tool for AsusWRT Merlin with charts for daily, weekly and monthly summaries. It tracks download/upload bandwidth as well as latency, jitter and packet loss.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You must be running firmware Merlin 384.15/384.13_4 or Fork 43E5 (or later) [Asu
 Using your preferred SSH client/terminal, copy and paste the following command, then press Enter:
 
 ```sh
-/usr/sbin/curl -fsL --retry 3 "https://raw.githubusercontent.com/AMTM-OSR/spdMerlin/master/install/spdmerlin.sh" -o /jffs/scripts/spdmerlin && chmod 0755 /jffs/scripts/spdmerlin && /jffs/scripts/spdmerlin install
+/usr/sbin/curl -fsL --retry 3 "https://raw.githubusercontent.com/AMTM-OSR/spdMerlin/master/spdmerlin.sh" -o /jffs/scripts/spdmerlin && chmod 0755 /jffs/scripts/spdmerlin && /jffs/scripts/spdmerlin install
 ```
 
 ## Usage


### PR DESCRIPTION
Fixed "duplicate column name" errors reported by SQLite3 during initial installation when the database "upgrade" was being performed.

The issue was reported in the SNB Forums:
https://www.snbforums.com/threads/sqlite3-errors-when-installing-latest-version.94858/#post-957558
