### PR TITLE
Remove Duplicate Configuration Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # spdMerlin
 
 ## v4.4.10
-### Updated on 2025-June-04
+### Updated on 2025-June-07
 ## About
 spdMerlin is an internet speedtest and monitoring tool for AsusWRT Merlin with charts for daily, weekly and monthly summaries. It tracks download/upload bandwidth as well as latency, jitter and packet loss.
 


### PR DESCRIPTION
Added/modified code to remove duplicate parameter key names found in the configuration file.
Getting some duplicate key values can cause "bad number" or "arithmetic syntax" errors.
