### PR TITLE
New CLI Parameters to Reset Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # spdMerlin
 
 ## v4.4.13
-### Updated on 2025-June-23
+### Updated on 2025-June-24
 
 ## About
 spdMerlin is an internet speedtest and monitoring tool for AsusWRT Merlin with charts for daily, weekly and monthly summaries. It tracks download/upload bandwidth as well as latency, jitter and packet loss.


### PR DESCRIPTION
Added new CLI parameters "**reset_interfaces force**" to allow users to manually recheck all interfaces and reset them in cases where an interface was previously "excluded" due to being found "disabled" but later becomes "enabled" and with ready status.