### PR TITLE
Bug Fix: '#excluded' marker update logic fix

### DIFF
--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -1461,7 +1461,8 @@ Set_Interface_State()
             then
                 # If it’s 'up' automatically exclude it #
                 sed -i "$1 s/$/ #excluded#/" "$SCRIPT_INTERFACES_USER"
-            else                # If it’s 'down' automatically exclude it with '- interface not up#' #
+            else
+				# If it’s 'down' automatically exclude it with '- interface not up#' #
                 sed -i "$1 s/$/ #excluded - interface not up#/" "$SCRIPT_INTERFACES_USER"
             fi
         fi


### PR DESCRIPTION
Logic of updating the '#excluded' marker when interfaces change status had a comment mistake (phrase "user wanted it included") and a missing logic if the interface is up when doing the marker update.

Additionally, since string substitutions specific to the marker using "sed" command are not unified throughout the script, which caused me a lot of trouble when troubleshooting this particular bug, I took the chance to do the code unification to the better format.