### PR TITLE
Workaround for Entware Binaries using RUNPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # spdMerlin
 
-## v4.4.18
-### Updated on 2026-Mar-21
+## v4.4.19
+### Updated on 2026-Apr-11
 
 ## About
 spdMerlin is an internet speedtest and monitoring tool for AsusWRT Merlin with charts for daily, weekly and monthly summaries. It tracks download/upload bandwidth as well as latency, jitter and packet loss.

--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -14,7 +14,7 @@
 ##     Forked from https://github.com/jackyaz/spdMerlin     ##
 ##                                                          ##
 ##############################################################
-# Last Modified: 2026-Mar-21
+# Last Modified: 2026-Apr-11
 #-------------------------------------------------------------
 
 ##############        Shellcheck directives      #############
@@ -38,8 +38,8 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="spdMerlin"
 readonly SCRIPT_NAME_LOWER="$(echo "$SCRIPT_NAME" | tr 'A-Z' 'a-z')"
-readonly SCRIPT_VERSION="v4.4.18"
-readonly SCRIPT_VERSTAG="26032122"
+readonly SCRIPT_VERSION="v4.4.19"
+readonly SCRIPT_VERSTAG="26041103"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
@@ -99,6 +99,9 @@ readonly SHARE_TEMP_DIR="/opt/share/tmp"
 readonly sqlDBLogFileSize=102400
 readonly sqlDBLogDateTime="%Y-%m-%d %H:%M:%S"
 readonly sqlDBLogFileName="${SCRIPT_NAME}_DBSQL_DEBUG.LOG"
+
+# Workaround for Entware ELF binaries compiled with RUNPATH #
+unset LD_LIBRARY_PATH
 
 # Give priority to built-in binaries #
 export PATH="/bin:/usr/bin:/sbin:/usr/sbin:$PATH"


### PR DESCRIPTION
Added "`unset LD_LIBRARY_PATH`" line as a workaround due to the latest Entware binaries using the **RUNPATH** embedded library search path mechanism instead of the previous **RPATH** method. **RUNPATH** is searched **AFTER** the LD_LIBRARY_PATH definitions, whereas **RPATH** has higher priority than the LD_LIBRARY_PATH environment variable, so it's searched **FIRST**.
